### PR TITLE
Make copy target path configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+- Make copy target path configurable
+
 ## [1.1.0] - 2020-11-19
 
 - Hide upload and bookmark buttons

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ The mozilla [pdf.js viewer](https://mozilla.github.io/pdf.js/web/viewer.html) as
 ## Usage
 
 This vue-cli plugin will copy all the required pdf.js files into the `public` folder.
-The viewer will then be available under the following URL: `{BASE_URL}/pdfjs/viewer.html?file=/example.pdf`.
+The viewer will then be available under the following URL: `{BASE_URL}/pdfjs/web/viewer.html?file=/example.pdf`.
 
 ## Updating
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ The mozilla [pdf.js viewer](https://mozilla.github.io/pdf.js/web/viewer.html) as
 This vue-cli plugin will copy all the required pdf.js files into the `public` folder.
 The viewer will then be available under the following URL: `{BASE_URL}/pdfjs/web/viewer.html?file=/example.pdf`.
 
+By providing a value for `pdfjsPath` under `pluginOptions` the default target path can be overridden. For example by setting the path to `public/assets/pdfjs` the pdf.js files will be available under `{BASE_URL}/assets/pdfjs/web/viewer.html?file=/example.pdf`.
+
 ## Updating
 
 In order to update the viewer, pdf.js [needs to be built](https://github.com/mozilla/pdf.js#building-pdfjs) and copied into the `assets` folder.

--- a/index.js
+++ b/index.js
@@ -1,14 +1,15 @@
 const CopyPlugin = require('copy-webpack-plugin')
 const path = require('path')
 
-module.exports = (api, options) => {
+module.exports = (api, { pluginOptions } = {}) => {
+  const pdfjsPath = pluginOptions && pluginOptions.pdfjsPath || 'public/pdfjs/'
   api.chainWebpack(webpackConfig => {
     webpackConfig
       .plugin('copy-pdfjs-viewer')
       .use(CopyPlugin, [[
           {
             from: path.join(__dirname, './assets'),
-            to: path.join(api.service.context, 'public/pdfjs/')
+            to: path.join(api.service.context, pdfjsPath)
           }
       ]])
   })


### PR DESCRIPTION
There was an issue with rewrite rules that became clear after the PR https://github.com/4teamwork/gever-ui/pull/1488 was merged. In order to use the plugin properly we have to copy the pdfjs source files to another than the default target path. With this PR the copy target path can be overriden by the project that uses the plugin.