### PR TITLE
Always force override existing pdfjs-folder in the copy-plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+- Always force override existing pdfjs-folder in the copy-plugin
+
 ## [1.3.0] - 2021-06-21
 - Upgrade PdfJS version from v2.7.285 to v2.8.335
 

--- a/index.js
+++ b/index.js
@@ -9,7 +9,8 @@ module.exports = (api, { pluginOptions } = {}) => {
       .use(CopyPlugin, [[
           {
             from: path.join(__dirname, './assets'),
-            to: path.join(api.service.context, pdfjsPath)
+            to: path.join(api.service.context, pdfjsPath),
+            force: true
           }
       ]])
   })


### PR DESCRIPTION
Otherwise a new version will not be applied on rebuild.

See: https://webpack.js.org/plugins/copy-webpack-plugin/#force